### PR TITLE
Fix bug reported in issue #41

### DIFF
--- a/R/assign_parameters.R
+++ b/R/assign_parameters.R
@@ -526,7 +526,9 @@ assign_parameters.curves <- function(
 )
 {
   # Delete duplicated type descriptions
-  x[duplicated(x$Type), 'Type'] <- ' '
+  is_duplicated <- duplicated(x[, c("Name", "Type")])
+  
+  x[["Type"]][is_duplicated] <- " "
   
   x
 }

--- a/tests/testthat/test-function-assign_parameters.curves.R
+++ b/tests/testthat/test-function-assign_parameters.curves.R
@@ -1,7 +1,21 @@
+#library(testthat)
 test_that("assign_parameters.curves() works", {
 
   f <- swmmr:::assign_parameters.curves
   
   expect_error(f())
 
+  x <- read.csv(text = c(
+    "Name,Type,X,Y",
+    "a,Pump1,1,2",
+    "a,Pump1,3,4",
+    "b,Pump2,5,6",
+    "b,Pump2,7,8",
+    "c,Pump3,7,8"
+  ))
+  
+  result <- f(x)
+  
+  expect_identical(result$Type, c("Pump1", " ", "Pump2", " ", "Pump3"))
+  
 })

--- a/tests/testthat/test-function-assign_parameters.curves.R
+++ b/tests/testthat/test-function-assign_parameters.curves.R
@@ -18,4 +18,9 @@ test_that("assign_parameters.curves() works", {
   
   expect_identical(result$Type, c("Pump1", " ", "Pump2", " ", "Pump3"))
   
+  #inp <- list(curves = result)
+  #class(inp) <- "inp"
+  #file <- tempfile(fileext = ".inp")
+  #swmmr:::write_inp(inp, file)
+  #writeLines(readLines(file))
 })


### PR DESCRIPTION
Look for duplicated values in both columns, "Name" and "Type" and not only in "Type" when deciding where to clear the "Type" field.

Implement a corresponding test